### PR TITLE
Add support for Azure for US Government OWA endpoint

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -25,7 +25,8 @@
     "matches": [
       "https://*/owa/*",
       "https://outlook.office.com/mail/*",
-      "https://outlook.office365.com/mail/*"
+      "https://outlook.office365.com/mail/*",
+      "https://outlook.office365.us/mail/*"
     ],
     "js": ["index.js"]
   }],


### PR DESCRIPTION
Azure for Government uses the .us TLD for its services, including OWA.  